### PR TITLE
Upgrade Next.js to ^15.2.4 and add Google site verification

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "framer-motion": "^12.4.7",
     "lucide-react": "^0.475.0",
     "motion": "^12.6.2",
-    "next": "15.1.7",
+    "next": "^15.2.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-icons": "^5.4.0",

--- a/public/google017eb166b875c421.html
+++ b/public/google017eb166b875c421.html
@@ -1,0 +1,1 @@
+google-site-verification: google017eb166b875c421.html

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,6 +18,9 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   title: 'Paperclip',
   description: 'Paperclip',
+  verification: {
+    google: 'iYKTFfiq7i4ZJOVTE4IO6zO7PpLc_4M6agNKoEDBBrY',
+  },
 };
 
 const poppins = Inter({


### PR DESCRIPTION
### Motivation
- Add Google Search Console site verification to allow ownership verification for the site.
- Pick up fixes/patches from a Next.js update by moving from `15.1.7` to `^15.2.4`.

### Description
- Bumped `next` in `package.json` from `15.1.7` to `^15.2.4`.
- Added `metadata.verification.google` entry in `src/app/layout.tsx` with the verification token.
- Added the verification file `public/google017eb166b875c421.html` containing the verification string.

### Testing
- Ran `npm run build` (`next build`) and the build completed successfully.
- Ran `npm run lint` (`next lint`) and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4c16d43d08330a7112aa511aec9cf)